### PR TITLE
Ignore out-of-range exception parsing meta box content encoding

### DIFF
--- a/Srcs/common/iteminfobox.cpp
+++ b/Srcs/common/iteminfobox.cpp
@@ -342,7 +342,11 @@ void ItemInfoEntry::parseBox(BitStream& bitstr)
         if (mItemType == "mime")
         {
             bitstr.readZeroTerminatedString(mContentType);
-            bitstr.readZeroTerminatedString(mContentEncoding);
+            try {
+                bitstr.readZeroTerminatedString(mContentEncoding);
+            } catch (std::out_of_range& e) {
+                // Some iPhone images break here, but it's not critical to the conversion
+            }
         }
         else if (mItemType == "uri ")
         {


### PR DESCRIPTION
I found an image uploaded from an iPhone that included meta info with content type "application/rdf+xml", and which crashed on out-of-range when trying to get the content encoding. Ignoring this line at that time does not have a negative impact on the final conversion.