### PR TITLE
Integrate upstream fix to iOS 11 parsing error

### DIFF
--- a/Srcs/common/bitstream.cpp
+++ b/Srcs/common/bitstream.cpp
@@ -339,8 +339,8 @@ void BitStream::readZeroTerminatedString(string& dstString)
     char currChar;
 
     dstString.clear();
-    currChar = read8Bits();
-    while (currChar != '\0')
+
+    while (mByteOffset != getSize() && (currChar = read8Bits()) != '\0')
     {
         dstString += currChar;
         currChar = read8Bits();

--- a/Srcs/common/iteminfobox.cpp
+++ b/Srcs/common/iteminfobox.cpp
@@ -342,11 +342,7 @@ void ItemInfoEntry::parseBox(BitStream& bitstr)
         if (mItemType == "mime")
         {
             bitstr.readZeroTerminatedString(mContentType);
-            try {
-                bitstr.readZeroTerminatedString(mContentEncoding);
-            } catch (std::out_of_range& e) {
-                // Some iPhone images break here, but it's not critical to the conversion
-            }
+            bitstr.readZeroTerminatedString(mContentEncoding);
         }
         else if (mItemType == "uri ")
         {


### PR DESCRIPTION
This reverts my last PR - I checked upstream and there's an un-merged PR waiting which fixes this the right way: https://github.com/nokiatech/heif/pull/15